### PR TITLE
🏷️ Fix deprecated types in `typing`

### DIFF
--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,5 +1,5 @@
 import tempfile
-import typing as t
+from collections import abc
 from unittest import mock
 
 import pytest
@@ -8,14 +8,14 @@ from tests import FixtureRequest
 
 
 @pytest.fixture(scope="module", autouse=True)
-def upload_basedir() -> t.Generator[str, None, None]:
+def upload_basedir() -> abc.Generator[str, None, None]:
     with tempfile.TemporaryDirectory() as tmpdir:
         with mock.patch("webapp_photo_luminescence.config.UPLOAD_BASEDIR", tmpdir):
             yield tmpdir
 
 
 @pytest.fixture()
-def upload_dir(upload_basedir: str) -> t.Generator[str, None, None]:
+def upload_dir(upload_basedir: str) -> abc.Generator[str, None, None]:
     with tempfile.TemporaryDirectory(dir=upload_basedir) as tmpdir:
         yield tmpdir
 


### PR DESCRIPTION
- Fix `typing.Generator` to `collections.abc.Generator`