### PR TITLE
⬆️ Bump tlab-analysis from 0.0.2 to 0.1.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
   "dash~=2.6.1",
   "dash-bootstrap-components~=1.2.1",
   "pandas~=1.4.4",
-  "tlab-analysis @ git+https://github.com/wasedatakeuchilab/tlab-analysis@v0.0.2",
+  "tlab-analysis @ git+https://github.com/wasedatakeuchilab/tlab-analysis@v0.1.0",
   "tlab-pptx @ git+https://github.com/wasedatakeuchilab/tlab-pptx@v0.0.2",
 ]
 dynamic = ["version"]


### PR DESCRIPTION
https://github.com/wasedatakeuchilab/tlab-analysis/releases/tag/v0.1.0